### PR TITLE
fix(projects): Fix the logic of root route redirection to home

### DIFF
--- a/src/router/routes/index.ts
+++ b/src/router/routes/index.ts
@@ -6,7 +6,7 @@ import { transformElegantRoutesToVueRoutes } from '../elegant/transform';
 export const ROOT_ROUTE: CustomRoute = {
   name: 'root',
   path: '/',
-  redirect: '/home',
+  redirect: import.meta.env.VITE_ROUTE_HOME || '/home',
   meta: {
     title: 'root',
     constant: true


### PR DESCRIPTION
现在在静态路由下如果修改了home，进入/还是会重定向至/home，而不是用户定义的新home