### PR TITLE
fix(components): fix non-props cannot penetrate

### DIFF
--- a/src/components/custom/svg-icon.vue
+++ b/src/components/custom/svg-icon.vue
@@ -47,7 +47,9 @@ const renderLocalIcon = computed(() => props.localIcon || !props.icon);
     </svg>
   </template>
   <template v-else>
-    <Icon v-if="icon" :icon="icon" v-bind="bindAttrs" />
+    <div v-bind="bindAttrs">
+      <Icon v-if="icon" :icon="icon" />
+    </div>
   </template>
 </template>
 


### PR DESCRIPTION
修复 svgicon 组件 class 无法透穿警告

![4928db13bf317f6ad83266772468448e](https://github.com/soybeanjs/soybean-admin/assets/18189346/28448e0f-8db5-4262-ac75-4abb293ea637)
