### PR TITLE
修复header按钮贴边以及按钮常亮的问题

### DIFF
--- a/src/components/custom/button-icon.vue
+++ b/src/components/custom/button-icon.vue
@@ -28,12 +28,6 @@ const props = withDefaults(defineProps<Props>(), {
   zIndex: 98
 });
 
-interface ButtonProps {
-  className: string;
-}
-
-const [DefineButton, Button] = createReusableTemplate<ButtonProps>();
-
 const cls = computed(() => {
   let clsStr = props.class;
 
@@ -47,12 +41,18 @@ const cls = computed(() => {
 
   return clsStr;
 });
+
+interface ButtonProps {
+  className: string;
+}
+
+const [DefineButton, Button] = createReusableTemplate<ButtonProps>();
 </script>
 
 <template>
   <!-- define component start: Button -->
   <DefineButton v-slot="{ $slots, className }">
-    <NButton quaternary :class="className">
+    <NButton quaternary :class="className" :focusable="false">
       <div class="flex-center gap-8px">
         <component :is="$slots.default" />
       </div>

--- a/src/layouts/modules/global-header/components/theme-button.vue
+++ b/src/layouts/modules/global-header/components/theme-button.vue
@@ -13,7 +13,7 @@ const appStore = useAppStore();
   <ButtonIcon
     icon="majesticons:color-swatch-line"
     :tooltip-content="$t('icon.themeConfig')"
-    @click="appStore.openThemeDrawer"
+    @click.stop="appStore.openThemeDrawer"
   />
 </template>
 

--- a/src/layouts/modules/global-header/index.vue
+++ b/src/layouts/modules/global-header/index.vue
@@ -47,7 +47,7 @@ const headerMenus = computed(() => {
 </script>
 
 <template>
-  <DarkModeContainer class="h-full flex-y-center shadow-header">
+  <DarkModeContainer class="h-full flex-y-center px-4 shadow-header">
     <GlobalLogo v-if="showLogo" class="h-full" :style="{ width: themeStore.sider.width + 'px' }" />
     <HorizontalMenu v-if="showMenu" mode="horizontal" :menus="headerMenus" class="px-12px" />
     <div v-else class="h-full flex-y-center flex-1-hidden">


### PR DESCRIPTION
1、给header加了1rem的p-x
2、这个按钮常亮在哪都会怪怪的，所以直接给`button-icon`组件的`NButton`设置`focusable`为`false`，让按钮不可被聚焦，抽屉开关的那个按钮加了个阻止冒泡的修饰符，没有的话依旧会常亮