### PR TITLE
optimize(components): accuracy draggable area for TableColumnSetting with animation

### DIFF
--- a/src/components/advanced/table-column-setting.vue
+++ b/src/components/advanced/table-column-setting.vue
@@ -21,10 +21,10 @@ const columns = defineModel<NaiveUI.TableColumnCheck[]>('columns', {
         {{ $t('common.columnSetting') }}
       </NButton>
     </template>
-    <VueDraggable v-model="columns">
+    <VueDraggable v-model="columns" :animation="150" filter=".none_draggable">
       <div v-for="item in columns" :key="item.key" class="h-36px flex-y-center rd-4px hover:(bg-primary bg-opacity-20)">
-        <icon-mdi-drag class="mr-8px cursor-move text-icon" />
-        <NCheckbox v-model:checked="item.checked">
+        <icon-mdi-drag class="mr-8px h-full cursor-move text-icon" />
+        <NCheckbox v-model:checked="item.checked" class="none_draggable flex-1">
           {{ item.title }}
         </NCheckbox>
       </div>


### PR DESCRIPTION
## 问题

表格列设置中，使用了拖动排序的功能并且提供了拖动块，并且拖动块在鼠标 `hover` 时显示 `move` 图标，在列标题的部分鼠标是不变化的

但目前整个单元格都可以进行拖动操作，这与用户预期不同，并且标题的部分没有占满行剩余空间，对于较短标题在点击单元格右侧空白处不会触发点击事件，见下图

![image](https://github.com/soybeanjs/soybean-admin/assets/48410934/388f6ca3-490b-4fc0-a53e-4bfdff963188)

> 其中红色是可以拖动的区域，蓝色是点击时触发的区域

## 更改

- 放大拖动块的区域和单元格同高度，在鼠标变化为 `move` 时，都可以对单元格进行拖动
- 标题区域撑满行剩余空间，所有标题的部分都可以进行点击
- 添加拖动动画，用户体验会更好
- 使用 `filter` 对 `checkbox` 元素进行过滤（添加类 `.none_draggable`），做到只有移动拖动块时单元格会进行拖动排序，拖动标题区域时不会触发排序