### PR TITLE
fix(components): 修复搜索回车不关闭弹框、点击无法跳转的问题

### DIFF
--- a/src/components/custom/button-icon.vue
+++ b/src/components/custom/button-icon.vue
@@ -33,7 +33,7 @@ const DEFAULT_CLASS = 'h-[36px] text-icon';
 <template>
   <NTooltip :placement="tooltipPlacement" :z-index="zIndex" :disabled="!tooltipContent">
     <template #trigger>
-      <NButton quaternary :class="twMerge(DEFAULT_CLASS, props.class)" v-bind="$attrs">
+      <NButton quaternary :class="twMerge(DEFAULT_CLASS, props.class)" v-bind="$attrs" :focusable="false">
         <div class="flex-center gap-8px">
           <slot>
             <SvgIcon :icon="icon" />

--- a/src/layouts/modules/global-search/components/search-modal.vue
+++ b/src/layouts/modules/global-search/components/search-modal.vue
@@ -112,7 +112,7 @@ registerShortcut();
 
     <div class="mt-20px">
       <NEmpty v-if="resultOptions.length === 0" :description="$t('common.noData')" />
-      <SearchResult v-else v-model:path="activePath" :options="resultOptions" @enter.prevent="handleEnter" />
+      <SearchResult v-else v-model:path="activePath" :options="resultOptions" @enter="handleEnter" />
     </div>
     <template #footer>
       <SearchFooter v-if="!isMobile" />

--- a/src/layouts/modules/global-search/components/search-result.vue
+++ b/src/layouts/modules/global-search/components/search-result.vue
@@ -39,7 +39,7 @@ function handleTo() {
             background: item.routePath === active ? theme.themeColor : '',
             color: item.routePath === active ? '#fff' : ''
           }"
-          @click="handleTo"
+          @click.prevent="handleTo"
           @mouseenter="handleMouseEnter(item)"
         >
           <component :is="item.icon" />


### PR DESCRIPTION
close #466 
1、控制台报错是因为阻止默认事件有点问题，可能是事件传递在vue中有更新？我看只有里面的click会触发这个`enter`事件，所以直接移里面去做了

2、除此之外回车触发跳转后弹窗会被重新打开，经过测试发现是`header`的按钮持续聚焦导致的，在按钮聚焦的时候只要在页面内按了回车都会导致按钮被触发点击事件，结果思考还是建议取消`ButtonIcon`组件内按钮的可聚焦状态，这样在不影响现有功能的情况下，有利于减少某些页面内绑定了回车事件时可能出现的bug