### PR TITLE
优化关于页面的`package.json`导入

### DIFF
--- a/src/views/about/index.vue
+++ b/src/views/about/index.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue';
 import { $t } from '@/locales';
 import { useAppStore } from '@/store/modules/app';
-import pkg from '~/package.json';
+import { dependencies, devDependencies, homepage, name, version, website } from '~/package.json';
 
 const appStore = useAppStore();
 
@@ -19,8 +19,6 @@ interface PkgVersionInfo {
   name: string;
   version: string;
 }
-
-const { name, version, dependencies, devDependencies } = pkg;
 
 function transformVersionData(tuple: [string, string]): PkgVersionInfo {
   const [$name, $version] = tuple;
@@ -54,12 +52,12 @@ const latestBuildTime = BUILD_TIME;
           <NTag type="primary">{{ latestBuildTime }}</NTag>
         </NDescriptionsItem>
         <NDescriptionsItem :label="$t('page.about.projectInfo.githubLink')">
-          <a class="text-primary" :href="pkg.homepage" target="_blank" rel="noopener noreferrer">
+          <a class="text-primary" :href="homepage" target="_blank" rel="noopener noreferrer">
             {{ $t('page.about.projectInfo.githubLink') }}
           </a>
         </NDescriptionsItem>
         <NDescriptionsItem :label="$t('page.about.projectInfo.previewLink')">
-          <a class="text-primary" :href="pkg.website" target="_blank" rel="noopener noreferrer">
+          <a class="text-primary" :href="website" target="_blank" rel="noopener noreferrer">
             {{ $t('page.about.projectInfo.previewLink') }}
           </a>
         </NDescriptionsItem>


### PR DESCRIPTION
避免把`json`中的无关属性完全导入到静态构建中，并作为`json`导入的例子。

- 存在泄漏构建无关的项目信息风险
- 减少构建后的打包大小

修改前：

<img width="334" alt="Snipaste_2024-06-19_11-41-33" src="https://github.com/soybeanjs/soybean-admin/assets/14545600/7d6247fd-0d60-4ac2-86fc-078cb2057707">

修改后：
<img width="314" alt="Snipaste_2024-06-19_11-49-54" src="https://github.com/soybeanjs/soybean-admin/assets/14545600/9317658b-fee8-4967-a7aa-534b5d643440">

