### PR TITLE
全局添加页面标题后缀

### DIFF
--- a/src/router/guard/title.ts
+++ b/src/router/guard/title.ts
@@ -8,6 +8,12 @@ export function createDocumentTitleGuard(router: Router) {
 
     const documentTitle = i18nKey ? $t(i18nKey) : title;
 
-    useTitle(documentTitle);
+    changeDocumentTitle(documentTitle);
+  });
+}
+
+export function changeDocumentTitle(documentTitle: string) {
+  useTitle(documentTitle, {
+    titleTemplate: `%s | ${import.meta.env.VITE_APP_TITLE}`
   });
 }

--- a/src/store/modules/app/index.ts
+++ b/src/store/modules/app/index.ts
@@ -1,12 +1,13 @@
 import { effectScope, nextTick, onScopeDispose, ref, watch } from 'vue';
 import { defineStore } from 'pinia';
-import { breakpointsTailwind, useBreakpoints, useEventListener, useTitle } from '@vueuse/core';
+import { breakpointsTailwind, useBreakpoints, useEventListener } from '@vueuse/core';
 import { useBoolean } from '@sa/hooks';
 import { SetupStoreId } from '@/enum';
 import { router } from '@/router';
 import { $t, setLocale } from '@/locales';
 import { setDayjsLocale } from '@/locales/dayjs';
 import { localStg } from '@/utils/storage';
+import { changeDocumentTitle } from '@/router/guard/title';
 import { useRouteStore } from '../route';
 import { useTabStore } from '../tab';
 import { useThemeStore } from '../theme';
@@ -73,7 +74,7 @@ export const useAppStore = defineStore(SetupStoreId.App, () => {
 
     const documentTitle = i18nKey ? $t(i18nKey) : title;
 
-    useTitle(documentTitle);
+    changeDocumentTitle(documentTitle);
   }
 
   function init() {


### PR DESCRIPTION
使用`VITE_APP_TITLE `作为标题默认追加后缀。

- 有利于多个项目（测试站点、正式站点、分叉项目）在浏览器明显区分。
- 能用作站点项目名称。

<img width="114" alt="Snipaste_2024-06-20_12-05-48" src="https://github.com/soybeanjs/soybean-admin/assets/14545600/1d08ee54-bc66-4d0f-bb31-c203a93b42d5">
