### PR TITLE
optimize(projects):  supports custom menu icon sizes

### DIFF
--- a/src/store/modules/route/shared.ts
+++ b/src/store/modules/route/shared.ts
@@ -123,7 +123,7 @@ function getGlobalMenuByBaseRoute(route: RouteLocationNormalizedLoaded | Elegant
   const { SvgIconVNode } = useSvgIcon();
 
   const { name, path } = route;
-  const { title, i18nKey, icon = import.meta.env.VITE_MENU_ICON, localIcon } = route.meta ?? {};
+  const { title, i18nKey, icon = import.meta.env.VITE_MENU_ICON, localIcon, iconFontSize } = route.meta ?? {};
 
   const label = i18nKey ? $t(i18nKey) : title!;
 
@@ -133,7 +133,7 @@ function getGlobalMenuByBaseRoute(route: RouteLocationNormalizedLoaded | Elegant
     i18nKey,
     routeKey: name as RouteKey,
     routePath: path as RouteMap[RouteKey],
-    icon: SvgIconVNode({ icon, localIcon, fontSize: 20 })
+    icon: SvgIconVNode({ icon, localIcon, fontSize: iconFontSize || 20 })
   };
 
   return menu;

--- a/src/typings/router.d.ts
+++ b/src/typings/router.d.ts
@@ -42,6 +42,8 @@ declare module 'vue-router' {
      * In "src/assets/svg-icon", if it is set, the icon will be ignored
      */
     localIcon?: string;
+    /** Icon size. width and height are the same. */
+    iconFontSize?: number;
     /** Router order */
     order?: number | null;
     /** The outer link of the route */


### PR DESCRIPTION
修改菜单栏的图标时( naive UI 的 Menu 组件)， 使用组件的 `theme-overrides` 方法修改图标大小无效。
原因：路由初始化使用 SvgIconVNode 方法，在 svg 的**根标签上注入了 `font-size`** 属性。导致 theme-overrides 在父元素设置的 `font-size` 无法影响到 svg 元素。
- 考虑到向前兼容的问题，RouteMeta 添加可选属性 iconFontSize，以控制图标大小
