### PR TITLE
fix: After the static route is switched, the interface goes blank

### DIFF
--- a/src/layouts/modules/global-content/index.vue
+++ b/src/layouts/modules/global-content/index.vue
@@ -43,13 +43,14 @@ function resetScroll() {
       @after-enter="appStore.setContentXScrollable(false)"
     >
       <KeepAlive :include="routeStore.cacheRoutes">
-        <component
-          :is="Component"
-          v-if="appStore.reloadFlag"
-          :key="tabStore.getTabIdByRoute(route)"
-          :class="{ 'p-16px': showPadding }"
-          class="flex-grow bg-layout transition-300"
-        />
+        <div class="size-full" :key="tabStore.getTabIdByRoute(route)"
+            :class="{ 'p-16px': showPadding }">
+          <component
+            :is="Component"
+            v-if="appStore.reloadFlag"
+            class="flex-grow bg-layout transition-300"
+          />
+        </div>
       </KeepAlive>
     </Transition>
   </RouterView>


### PR DESCRIPTION
## Pull Request 详情

静态路由切换后，控制台出现警告信息。
Component inside ＜Transition＞ renders non-element root node that cannot be animated.
同时会导致，界面空白。路由切换成功，但页面渲染失败。

## 版本信息

v1.0-beta

## 解决了哪些问题

解决静态路由切换后，不显示组件问题

## 是否关闭了某个 Issue

否