### PR TITLE
fix(hooks): prevent program freezing when pagesize returns 0

### DIFF
--- a/src/hooks/common/table.ts
+++ b/src/hooks/common/table.ts
@@ -40,17 +40,20 @@ export function useTable<A extends NaiveUI.TableApiFn>(config: NaiveUI.NaiveTabl
     transformer: res => {
       const { records = [], current = 1, size = 10, total = 0 } = res.data || {};
 
+      // Ensure that the size is greater than 0, If it is less than 0, it will cause paging calculation errors.
+      const pageSize = size <= 0 ? 10 : size;
+
       const recordsWithIndex = records.map((item, index) => {
         return {
           ...item,
-          index: (current - 1) * size + index + 1
+          index: (current - 1) * pageSize + index + 1
         };
       });
 
       return {
         data: recordsWithIndex,
         pageNum: current,
-        pageSize: size,
+        pageSize,
         total
       };
     },


### PR DESCRIPTION
防止接口的分页大小返回0的时候页面卡死，考虑到部分系统无返回该内容、没有使用组件库的分页器或是有对应的ORM做了这个限制，所以就不放到`useTableHook`里了，在`transformer`里做一个简单的拦截+提示就行，避免这个`size`变为“魔法值”