### PR TITLE
fix(utils): 修复windows系统下使用vscode的i18nAlly插件无法新增多语言的问题

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
   "editor.formatOnSave": false,
   "eslint.validate": ["html", "css", "scss", "json", "jsonc"],
   "i18n-ally.displayLanguage": "zh-cn",
-  "i18n-ally.enabledParsers": ["ts"],
+  "i18n-ally.enabledParsers": ["ts", "json"],
   "i18n-ally.enabledFrameworks": ["vue"],
   "i18n-ally.editor.preferEditor": true,
   "i18n-ally.keystyle": "nested",

--- a/src/locales/langs/en-us.json
+++ b/src/locales/langs/en-us.json
@@ -1,0 +1,3 @@
+{
+  "test": "Test i18ally inserting vscode into the window system"
+}

--- a/src/locales/langs/en-us.ts
+++ b/src/locales/langs/en-us.ts
@@ -1,3 +1,5 @@
+import enUS from './en-us.json';
+
 const local: App.I18n.Schema = {
   system: {
     title: 'SoybeanAdmin',
@@ -281,7 +283,8 @@ const local: App.I18n.Schema = {
   },
   datatable: {
     itemCount: 'Total {total} items'
-  }
+  },
+  ...enUS
 };
 
 export default local;

--- a/src/locales/langs/zh-cn.json
+++ b/src/locales/langs/zh-cn.json
@@ -1,0 +1,3 @@
+{
+  "test": "测试插入window系统下vscode的i18nally"
+}

--- a/src/locales/langs/zh-cn.ts
+++ b/src/locales/langs/zh-cn.ts
@@ -1,3 +1,5 @@
+import zhCN from './zh-cn.json';
+
 const local: App.I18n.Schema = {
   system: {
     title: 'Soybean 管理系统',
@@ -281,7 +283,8 @@ const local: App.I18n.Schema = {
   },
   datatable: {
     itemCount: '共 {total} 条'
-  }
+  },
+  ...zhCN
 };
 
 export default local;


### PR DESCRIPTION
修复windows系统下使用vscode的i18nAlly插件无法新增多语言的问题，新增时记得选择.json后缀的文件新增~