### PR TITLE
chore(types): remove type declaration for document.startViewTransitio…

### DIFF
--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -14,14 +14,6 @@ declare global {
     $notification?: import('naive-ui').NotificationProviderInst;
   }
 
-  interface ViewTransition {
-    ready: Promise<void>;
-  }
-
-  export interface Document {
-    startViewTransition?: (callback: () => Promise<void> | void) => ViewTransition;
-  }
-
   /** Build time of the project */
   export const BUILD_TIME: string;
 }


### PR DESCRIPTION
…n (TypeScript 5.6 includes it)

typescript 5.6 已经包含声明，无需定义。且目前的定义与上游存在类型冲突。
https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/#lib.d.ts