### PR TITLE
feat: add subpackage `@sa/alova`, refactor example with this package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@antv/g2": "5.2.5",
     "@better-scroll/core": "2.5.1",
     "@iconify/vue": "4.1.2",
-    "@sa/axios": "workspace:*",
+    "@sa/alova": "workspace:*",
     "@sa/color": "workspace:*",
     "@sa/hooks": "workspace:*",
     "@sa/materials": "workspace:*",

--- a/packages/hooks/src/use-table.ts
+++ b/packages/hooks/src/use-table.ts
@@ -1,12 +1,13 @@
 import { computed, reactive, ref } from 'vue';
 import type { Ref } from 'vue';
 import { jsonClone } from '@sa/utils';
+import { usePagination } from '@sa/alova/client';
+import type { AlovaGenerics, Method } from '@sa/alova';
 import useBoolean from './use-boolean';
-import useLoading from './use-loading';
 
 export type MaybePromise<T> = T | Promise<T>;
 
-export type ApiFn = (args: any) => Promise<unknown>;
+export type ApiFn = (args: any) => Method<AlovaGenerics>;
 
 export type TableColumnCheck = {
   key: string;
@@ -16,14 +17,7 @@ export type TableColumnCheck = {
 
 export type TableDataWithIndex<T> = T & { index: number };
 
-export type TransformedData<T> = {
-  data: TableDataWithIndex<T>[];
-  pageNum: number;
-  pageSize: number;
-  total: number;
-};
-
-export type Transformer<T, Response> = (response: Response) => TransformedData<T>;
+export type Transformer<T, Response> = (response: Response) => TableDataWithIndex<T>[];
 
 export type TableConfig<A extends ApiFn, T, C> = {
   /** api function to get table data */
@@ -31,7 +25,7 @@ export type TableConfig<A extends ApiFn, T, C> = {
   /** api params */
   apiParams?: Parameters<A>[0];
   /** transform api response to table data */
-  transformer: Transformer<T, Awaited<ReturnType<A>>>;
+  transformer: Transformer<T, Awaited<ReturnType<ReturnType<A>['send']>>>;
   /** columns factory */
   columns: () => C[];
   /**
@@ -47,12 +41,6 @@ export type TableConfig<A extends ApiFn, T, C> = {
    */
   getColumns: (columns: C[], checks: TableColumnCheck[]) => C[];
   /**
-   * callback when response fetched
-   *
-   * @param transformed transformed data
-   */
-  onFetched?: (transformed: TransformedData<T>) => MaybePromise<void>;
-  /**
    * whether to get data immediately
    *
    * @default true
@@ -61,7 +49,6 @@ export type TableConfig<A extends ApiFn, T, C> = {
 };
 
 export default function useHookTable<A extends ApiFn, T, C>(config: TableConfig<A, T, C>) {
-  const { loading, startLoading, endLoading } = useLoading();
   const { bool: empty, setBool: setEmpty } = useBoolean();
 
   const { apiFn, apiParams, transformer, immediate = true, getColumnChecks, getColumns } = config;
@@ -70,11 +57,21 @@ export default function useHookTable<A extends ApiFn, T, C>(config: TableConfig<
 
   const allColumns = ref(config.columns()) as Ref<C[]>;
 
-  const data: Ref<TableDataWithIndex<T>[]> = ref([]);
-
   const columnChecks: Ref<TableColumnCheck[]> = ref(getColumnChecks(config.columns()));
 
   const columns = computed(() => getColumns(allColumns.value, columnChecks.value));
+
+  const states = usePagination<ReturnType<A> extends Method<infer AG> ? AG : never, ReturnType<typeof transformer>>(
+    (page, size) => apiFn({ ...formatSearchParams(searchParams), page, size }) as any,
+    {
+      immediate,
+      data: transformer,
+      total: res => res.total
+    }
+  ).onSuccess(({ data }) => {
+    setEmpty(data.length === 0);
+  });
+  Reflect.deleteProperty(states, 'uploading');
 
   function reloadColumns() {
     allColumns.value = config.columns();
@@ -89,33 +86,13 @@ export default function useHookTable<A extends ApiFn, T, C>(config: TableConfig<
     }));
   }
 
-  async function getData() {
-    startLoading();
-
-    const formattedParams = formatSearchParams(searchParams);
-
-    const response = await apiFn(formattedParams);
-
-    const transformed = transformer(response as Awaited<ReturnType<A>>);
-
-    data.value = transformed.data;
-
-    setEmpty(transformed.data.length === 0);
-
-    await config.onFetched?.(transformed);
-
-    endLoading();
-  }
-
   function formatSearchParams(params: Record<string, unknown>) {
     const formattedParams: Record<string, unknown> = {};
-
     Object.entries(params).forEach(([key, value]) => {
       if (value !== null && value !== undefined) {
         formattedParams[key] = value;
       }
     });
-
     return formattedParams;
   }
 
@@ -133,18 +110,13 @@ export default function useHookTable<A extends ApiFn, T, C>(config: TableConfig<
     Object.assign(searchParams, jsonClone(apiParams));
   }
 
-  if (immediate) {
-    getData();
-  }
-
   return {
-    loading,
+    ...states,
     empty,
-    data,
     columns,
     columnChecks,
     reloadColumns,
-    getData,
+    getData: states.send,
     searchParams,
     updateSearchParams,
     resetSearchParams

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,9 @@ importers:
       '@iconify/vue':
         specifier: 4.1.2
         version: 4.1.2(vue@3.5.11(typescript@5.6.3))
-      '@sa/axios':
+      '@sa/alova':
         specifier: workspace:*
-        version: link:packages/axios
+        version: link:packages/alova
       '@sa/color':
         specifier: workspace:*
         version: link:packages/color

--- a/src/layouts/modules/global-menu/modules/vertical-mix-menu.vue
+++ b/src/layouts/modules/global-menu/modules/vertical-mix-menu.vue
@@ -14,7 +14,7 @@ import FirstLevelMenu from '../components/first-level-menu.vue';
 import GlobalLogo from '../../global-logo/index.vue';
 
 defineOptions({
-  name: 'VerticalMixMenu'
+  name: 'VerticalMenuMix'
 });
 
 const route = useRoute();

--- a/src/service/api/auth.ts
+++ b/src/service/api/auth.ts
@@ -1,4 +1,4 @@
-import { request } from '../request';
+import { alova } from '../request';
 
 /**
  * Login
@@ -7,19 +7,12 @@ import { request } from '../request';
  * @param password Password
  */
 export function fetchLogin(userName: string, password: string) {
-  return request<Api.Auth.LoginToken>({
-    url: '/auth/login',
-    method: 'post',
-    data: {
-      userName,
-      password
-    }
-  });
+  return alova.Post<Api.Auth.LoginToken>('/auth/login', { userName, password });
 }
 
 /** Get user info */
 export function fetchGetUserInfo() {
-  return request<Api.Auth.UserInfo>({ url: '/auth/getUserInfo' });
+  return alova.Get<Api.Auth.UserInfo>('/auth/getUserInfo');
 }
 
 /**
@@ -28,13 +21,15 @@ export function fetchGetUserInfo() {
  * @param refreshToken Refresh token
  */
 export function fetchRefreshToken(refreshToken: string) {
-  return request<Api.Auth.LoginToken>({
-    url: '/auth/refreshToken',
-    method: 'post',
-    data: {
-      refreshToken
+  return alova.Post<Api.Auth.LoginToken>(
+    '/auth/refreshToken',
+    { refreshToken },
+    {
+      meta: {
+        authRole: 'refreshToken'
+      }
     }
-  });
+  );
 }
 
 /**
@@ -44,5 +39,8 @@ export function fetchRefreshToken(refreshToken: string) {
  * @param msg error message
  */
 export function fetchCustomBackendError(code: string, msg: string) {
-  return request({ url: '/auth/error', params: { code, msg } });
+  return alova.Get('/auth/error', {
+    params: { code, msg },
+    shareRequest: false
+  });
 }

--- a/src/service/api/route.ts
+++ b/src/service/api/route.ts
@@ -1,13 +1,13 @@
-import { request } from '../request';
+import { alova } from '../request';
 
 /** get constant routes */
 export function fetchGetConstantRoutes() {
-  return request<Api.Route.MenuRoute[]>({ url: '/route/getConstantRoutes' });
+  return alova.Get<Api.Route.MenuRoute[]>('/route/getConstantRoutes');
 }
 
 /** get user routes */
 export function fetchGetUserRoutes() {
-  return request<Api.Route.UserRoute>({ url: '/route/getUserRoutes' });
+  return alova.Get<Api.Route.UserRoute>('/route/getUserRoutes');
 }
 
 /**
@@ -16,5 +16,5 @@ export function fetchGetUserRoutes() {
  * @param routeName route name
  */
 export function fetchIsRouteExist(routeName: string) {
-  return request<boolean>({ url: '/route/isRouteExist', params: { routeName } });
+  return alova.Get<boolean>('/route/isRouteExist', { params: { routeName } });
 }

--- a/src/service/api/system-manage.ts
+++ b/src/service/api/system-manage.ts
@@ -1,12 +1,8 @@
-import { request } from '../request';
+import { alova } from '../request';
 
 /** get role list */
 export function fetchGetRoleList(params?: Api.SystemManage.RoleSearchParams) {
-  return request<Api.SystemManage.RoleList>({
-    url: '/systemManage/getRoleList',
-    method: 'get',
-    params
-  });
+  return alova.Get<Api.SystemManage.RoleList>('/systemManage/getRoleList', { params });
 }
 
 /**
@@ -15,41 +11,25 @@ export function fetchGetRoleList(params?: Api.SystemManage.RoleSearchParams) {
  * these roles are all enabled
  */
 export function fetchGetAllRoles() {
-  return request<Api.SystemManage.AllRole[]>({
-    url: '/systemManage/getAllRoles',
-    method: 'get'
-  });
+  return alova.Get<Api.SystemManage.AllRole[]>('/systemManage/getAllRoles');
 }
 
 /** get user list */
 export function fetchGetUserList(params?: Api.SystemManage.UserSearchParams) {
-  return request<Api.SystemManage.UserList>({
-    url: '/systemManage/getUserList',
-    method: 'get',
-    params
-  });
+  return alova.Get<Api.SystemManage.UserList>('/systemManage/getUserList', { params });
 }
 
 /** get menu list */
 export function fetchGetMenuList() {
-  return request<Api.SystemManage.MenuList>({
-    url: '/systemManage/getMenuList/v2',
-    method: 'get'
-  });
+  return alova.Get<Api.SystemManage.MenuList>('/systemManage/getMenuList/v2');
 }
 
 /** get all pages */
 export function fetchGetAllPages() {
-  return request<string[]>({
-    url: '/systemManage/getAllPages',
-    method: 'get'
-  });
+  return alova.Get<string[]>('/systemManage/getAllPages');
 }
 
 /** get menu tree */
 export function fetchGetMenuTree() {
-  return request<Api.SystemManage.MenuTree[]>({
-    url: '/systemManage/getMenuTree',
-    method: 'get'
-  });
+  return alova.Get<Api.SystemManage.MenuTree[]>('/systemManage/getMenuTree');
 }

--- a/src/service/request/index.ts
+++ b/src/service/request/index.ts
@@ -1,67 +1,86 @@
-import type { AxiosResponse } from 'axios';
-import { BACKEND_ERROR_CODE, createFlatRequest, createRequest } from '@sa/axios';
+import { createAlovaRequest } from '@sa/alova';
 import { useAuthStore } from '@/store/modules/auth';
 import { $t } from '@/locales';
-import { localStg } from '@/utils/storage';
 import { getServiceBaseURL } from '@/utils/service';
-import { getAuthorization, handleExpiredRequest, showErrorMsg } from './shared';
+import { getAuthorization, handleRefreshToken, showErrorMsg } from './shared';
 import type { RequestInstanceState } from './type';
 
 const isHttpProxy = import.meta.env.DEV && import.meta.env.VITE_HTTP_PROXY === 'Y';
-const { baseURL, otherBaseURL } = getServiceBaseURL(import.meta.env, isHttpProxy);
+const { baseURL } = getServiceBaseURL(import.meta.env, isHttpProxy);
 
-export const request = createFlatRequest<App.Service.Response, RequestInstanceState>(
+const state: RequestInstanceState = {
+  errMsgStack: []
+};
+export const alova = createAlovaRequest(
   {
-    baseURL,
-    headers: {
-      apifoxToken: 'XL299LiMEDZ0H5h3A29PxwQXdMJqWyY2'
-    }
+    baseURL
   },
   {
-    async onRequest(config) {
+    onRequest({ config }) {
       const Authorization = getAuthorization();
-      Object.assign(config.headers, { Authorization });
-
-      return config;
+      config.headers.Authorization = Authorization;
+      config.headers.apifoxToken = 'XL299LiMEDZ0H5h3A29PxwQXdMJqWyY2';
     },
-    isBackendSuccess(response) {
+    tokenRefresher: {
+      async isExpired(response) {
+        const expiredTokenCodes = import.meta.env.VITE_SERVICE_EXPIRED_TOKEN_CODES?.split(',') || [];
+        const { code } = await response.clone().json();
+        return expiredTokenCodes.includes(String(code));
+      },
+      async handler() {
+        await handleRefreshToken();
+      }
+    },
+    async isBackendSuccess(response) {
       // when the backend response code is "0000"(default), it means the request is success
       // to change this logic by yourself, you can modify the `VITE_SERVICE_SUCCESS_CODE` in `.env` file
-      return String(response.data.code) === import.meta.env.VITE_SERVICE_SUCCESS_CODE;
+      const resp = response.clone();
+      const data = await resp.json();
+      return String(data.code) === import.meta.env.VITE_SERVICE_SUCCESS_CODE;
     },
-    async onBackendFail(response, instance) {
+    async transformBackendResponse(response) {
+      return (await response.clone().json()).data;
+    },
+    async onError(error, response) {
       const authStore = useAuthStore();
-      const responseCode = String(response.data.code);
+
+      let message = error.message;
+      let responseCode = '';
+      if (response) {
+        const data = await response?.clone().json();
+        message = data.msg;
+        responseCode = String(data.code);
+      }
 
       function handleLogout() {
+        showErrorMsg(state, message);
         authStore.resetStore();
       }
 
       function logoutAndCleanup() {
         handleLogout();
         window.removeEventListener('beforeunload', handleLogout);
-
-        request.state.errMsgStack = request.state.errMsgStack.filter(msg => msg !== response.data.msg);
+        state.errMsgStack = state.errMsgStack.filter(msg => msg !== message);
       }
 
       // when the backend response code is in `logoutCodes`, it means the user will be logged out and redirected to login page
       const logoutCodes = import.meta.env.VITE_SERVICE_LOGOUT_CODES?.split(',') || [];
       if (logoutCodes.includes(responseCode)) {
         handleLogout();
-        return null;
+        throw error;
       }
 
       // when the backend response code is in `modalLogoutCodes`, it means the user will be logged out by displaying a modal
       const modalLogoutCodes = import.meta.env.VITE_SERVICE_MODAL_LOGOUT_CODES?.split(',') || [];
-      if (modalLogoutCodes.includes(responseCode) && !request.state.errMsgStack?.includes(response.data.msg)) {
-        request.state.errMsgStack = [...(request.state.errMsgStack || []), response.data.msg];
+      if (modalLogoutCodes.includes(responseCode) && !state.errMsgStack?.includes(message)) {
+        state.errMsgStack = [...(state.errMsgStack || []), message];
 
         // prevent the user from refreshing the page
         window.addEventListener('beforeunload', handleLogout);
 
         window.$dialog?.error({
           title: $t('common.error'),
-          content: response.data.msg,
+          content: message,
           positiveText: $t('common.confirm'),
           maskClosable: false,
           closeOnEsc: false,
@@ -72,95 +91,10 @@ export const request = createFlatRequest<App.Service.Response, RequestInstanceSt
             logoutAndCleanup();
           }
         });
-
-        return null;
+        throw error;
       }
-
-      // when the backend response code is in `expiredTokenCodes`, it means the token is expired, and refresh token
-      // the api `refreshToken` can not return error code in `expiredTokenCodes`, otherwise it will be a dead loop, should return `logoutCodes` or `modalLogoutCodes`
-      const expiredTokenCodes = import.meta.env.VITE_SERVICE_EXPIRED_TOKEN_CODES?.split(',') || [];
-      if (expiredTokenCodes.includes(responseCode)) {
-        const success = await handleExpiredRequest(request.state);
-        if (success) {
-          const Authorization = getAuthorization();
-          Object.assign(response.config.headers, { Authorization });
-
-          return instance.request(response.config) as Promise<AxiosResponse>;
-        }
-      }
-
-      return null;
-    },
-    transformBackendResponse(response) {
-      return response.data.data;
-    },
-    onError(error) {
-      // when the request is fail, you can show error message
-
-      let message = error.message;
-      let backendErrorCode = '';
-
-      // get backend error message and code
-      if (error.code === BACKEND_ERROR_CODE) {
-        message = error.response?.data?.msg || message;
-        backendErrorCode = String(error.response?.data?.code || '');
-      }
-
-      // the error message is displayed in the modal
-      const modalLogoutCodes = import.meta.env.VITE_SERVICE_MODAL_LOGOUT_CODES?.split(',') || [];
-      if (modalLogoutCodes.includes(backendErrorCode)) {
-        return;
-      }
-
-      // when the token is expired, refresh token and retry request, so no need to show error message
-      const expiredTokenCodes = import.meta.env.VITE_SERVICE_EXPIRED_TOKEN_CODES?.split(',') || [];
-      if (expiredTokenCodes.includes(backendErrorCode)) {
-        return;
-      }
-
-      showErrorMsg(request.state, message);
-    }
-  }
-);
-
-export const demoRequest = createRequest<App.Service.DemoResponse>(
-  {
-    baseURL: otherBaseURL.demo
-  },
-  {
-    async onRequest(config) {
-      const { headers } = config;
-
-      // set token
-      const token = localStg.get('token');
-      const Authorization = token ? `Bearer ${token}` : null;
-      Object.assign(headers, { Authorization });
-
-      return config;
-    },
-    isBackendSuccess(response) {
-      // when the backend response code is "200", it means the request is success
-      // you can change this logic by yourself
-      return response.data.status === '200';
-    },
-    async onBackendFail(_response) {
-      // when the backend response code is not "200", it means the request is fail
-      // for example: the token is expired, refresh token and retry request
-    },
-    transformBackendResponse(response) {
-      return response.data.result;
-    },
-    onError(error) {
-      // when the request is fail, you can show error message
-
-      let message = error.message;
-
-      // show backend error message
-      if (error.code === BACKEND_ERROR_CODE) {
-        message = error.response?.data?.message || message;
-      }
-
-      window.$message?.error(message);
+      showErrorMsg(state, message);
+      throw error;
     }
   }
 );

--- a/src/service/request/type.ts
+++ b/src/service/request/type.ts
@@ -1,6 +1,4 @@
 export interface RequestInstanceState {
-  /** whether the request is refreshing token */
-  refreshTokenFn: Promise<boolean> | null;
   /** the request error message stack */
   errMsgStack: string[];
 }

--- a/src/store/modules/auth/index.ts
+++ b/src/store/modules/auth/index.ts
@@ -63,9 +63,8 @@ export const useAuthStore = defineStore(SetupStoreId.Auth, () => {
   async function login(userName: string, password: string, redirect = true) {
     startLoading();
 
-    const { data: loginToken, error } = await fetchLogin(userName, password);
-
-    if (!error) {
+    try {
+      const loginToken = await fetchLogin(userName, password);
       const pass = await loginByToken(loginToken);
 
       if (pass) {
@@ -81,7 +80,7 @@ export const useAuthStore = defineStore(SetupStoreId.Auth, () => {
           });
         }
       }
-    } else {
+    } catch {
       resetStore();
     }
 
@@ -106,16 +105,15 @@ export const useAuthStore = defineStore(SetupStoreId.Auth, () => {
   }
 
   async function getUserInfo() {
-    const { data: info, error } = await fetchGetUserInfo();
-
-    if (!error) {
+    try {
+      const info = await fetchGetUserInfo();
       // update store
       Object.assign(userInfo, info);
 
       return true;
+    } catch {
+      return false;
     }
-
-    return false;
   }
 
   async function initUserInfo() {

--- a/src/store/modules/route/index.ts
+++ b/src/store/modules/route/index.ts
@@ -201,11 +201,10 @@ export const useRouteStore = defineStore(SetupStoreId.Route, () => {
     if (authRouteMode.value === 'static') {
       addConstantRoutes(staticRoute.constantRoutes);
     } else {
-      const { data, error } = await fetchGetConstantRoutes();
-
-      if (!error) {
+      try {
+        const data = await fetchGetConstantRoutes();
         addConstantRoutes(data);
-      } else {
+      } catch {
         // if fetch constant routes failed, use static constant routes
         addConstantRoutes(staticRoute.constantRoutes);
       }
@@ -246,9 +245,9 @@ export const useRouteStore = defineStore(SetupStoreId.Route, () => {
 
   /** Init dynamic auth route */
   async function initDynamicAuthRoute() {
-    const { data, error } = await fetchGetUserRoutes();
+    try {
+      const data = await fetchGetUserRoutes();
 
-    if (!error) {
       const { routes, home } = data;
 
       addAuthRoutes(routes);
@@ -260,7 +259,7 @@ export const useRouteStore = defineStore(SetupStoreId.Route, () => {
       handleUpdateRootRouteRedirect(home);
 
       setIsInitAuthRoute(true);
-    } else {
+    } catch {
       // if fetch user routes failed, reset store
       authStore.resetStore();
     }
@@ -340,9 +339,7 @@ export const useRouteStore = defineStore(SetupStoreId.Route, () => {
       return isRouteExistByRouteName(routeName, staticAuthRoutes);
     }
 
-    const { data } = await fetchIsRouteExist(routeName);
-
-    return data;
+    return fetchIsRouteExist(routeName);
   }
 
   /**

--- a/src/store/modules/route/shared.ts
+++ b/src/store/modules/route/shared.ts
@@ -19,7 +19,7 @@ export function filterAuthRoutesByRoles(routes: ElegantConstRoute[], roles: stri
  * @param route Auth route
  * @param roles Roles
  */
-function filterAuthRouteByRoles(route: ElegantConstRoute, roles: string[]): ElegantConstRoute[] {
+function filterAuthRouteByRoles(route: ElegantConstRoute, roles: string[]) {
   const routeRoles = (route.meta && route.meta.roles) || [];
 
   // if the route's "roles" is empty, then it is allowed to access
@@ -32,11 +32,6 @@ function filterAuthRouteByRoles(route: ElegantConstRoute, roles: string[]): Eleg
 
   if (filterRoute.children?.length) {
     filterRoute.children = filterRoute.children.flatMap(item => filterAuthRouteByRoles(item, roles));
-  }
-
-  // Exclude the route if it has no children after filtering
-  if (filterRoute.children?.length === 0) {
-    return [];
   }
 
   return hasPermission || isEmptyRoles ? [filterRoute] : [];
@@ -288,7 +283,8 @@ export function getBreadcrumbsByRoute(
 
   for (const menu of menus) {
     if (menu.key === key) {
-      return [transformMenuToBreadcrumb(menu)];
+      const breadcrumbMenu = menu;
+      return [transformMenuToBreadcrumb(breadcrumbMenu)];
     }
 
     if (menu.key === activeKey) {

--- a/src/typings/components.d.ts
+++ b/src/typings/components.d.ts
@@ -87,6 +87,7 @@ declare module 'vue' {
     NSelect: typeof import('naive-ui')['NSelect']
     NSkeleton: typeof import('naive-ui')['NSkeleton']
     NSpace: typeof import('naive-ui')['NSpace']
+    NSpin: typeof import('naive-ui')['NSpin']
     NStatistic: typeof import('naive-ui')['NStatistic']
     NSwitch: typeof import('naive-ui')['NSwitch']
     NTab: typeof import('naive-ui')['NTab']

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -14,6 +14,14 @@ declare global {
     $notification?: import('naive-ui').NotificationProviderInst;
   }
 
+  interface ViewTransition {
+    ready: Promise<void>;
+  }
+
+  export interface Document {
+    startViewTransition?: (callback: () => Promise<void> | void) => ViewTransition;
+  }
+
   /** Build time of the project */
   export const BUILD_TIME: string;
 }

--- a/src/typings/naive-ui.d.ts
+++ b/src/typings/naive-ui.d.ts
@@ -9,7 +9,6 @@ declare namespace NaiveUI {
   type PaginationProps = import('naive-ui').PaginationProps;
   type TableColumnCheck = import('@sa/hooks').TableColumnCheck;
   type TableDataWithIndex<T> = import('@sa/hooks').TableDataWithIndex<T>;
-  type FlatResponseData<T> = import('@sa/axios').FlatResponseData<T>;
 
   /**
    * the custom column key
@@ -26,9 +25,9 @@ declare namespace NaiveUI {
 
   type TableColumn<T> = TableColumnWithKey<T> | DataTableSelectionColumn<T> | DataTableExpandColumn<T>;
 
-  type TableApiFn<T = any, R = Api.Common.CommonSearchParams> = (
+  type TableAlovaApiFn<T = any, R = Api.Common.CommonSearchParams> = (
     params: R
-  ) => Promise<FlatResponseData<Api.Common.PaginatingQueryRecord<T>>>;
+  ) => import('@sa/alova').Method<import('@sa/alova').AlovaGenerics<Api.Common.PaginatingQueryRecord<T>>>;
 
   /**
    * the type of table operation
@@ -38,9 +37,9 @@ declare namespace NaiveUI {
    */
   type TableOperateType = 'add' | 'edit';
 
-  type GetTableData<A extends TableApiFn> = A extends TableApiFn<infer T> ? T : never;
+  type GetTableData<A extends TableAlovaApiFn> = A extends TableAlovaApiFn<infer T> ? T : never;
 
-  type NaiveTableConfig<A extends TableApiFn> = Pick<
+  type NaiveTableConfig<A extends TableAlovaApiFn> = Pick<
     import('@sa/hooks').TableConfig<A, GetTableData<A>, TableColumn<TableDataWithIndex<GetTableData<A>>>>,
     'apiFn' | 'apiParams' | 'columns' | 'immediate'
   > & {

--- a/src/views/_builtin/login/modules/code-login.vue
+++ b/src/views/_builtin/login/modules/code-login.vue
@@ -40,7 +40,7 @@ async function handleSubmit() {
 </script>
 
 <template>
-  <NForm ref="formRef" :model="model" :rules="rules" size="large" :show-label="false" @keyup.enter="handleSubmit">
+  <NForm ref="formRef" :model="model" :rules="rules" size="large" :show-label="false">
     <NFormItem path="phone">
       <NInput v-model:value="model.phone" :placeholder="$t('page.login.common.phonePlaceholder')" />
     </NFormItem>

--- a/src/views/_builtin/login/modules/pwd-login.vue
+++ b/src/views/_builtin/login/modules/pwd-login.vue
@@ -75,7 +75,7 @@ async function handleAccountLogin(account: Account) {
 </script>
 
 <template>
-  <NForm ref="formRef" :model="model" :rules="rules" size="large" :show-label="false" @keyup.enter="handleSubmit">
+  <NForm ref="formRef" :model="model" :rules="rules" size="large" :show-label="false">
     <NFormItem path="userName">
       <NInput v-model:value="model.userName" :placeholder="$t('page.login.common.userNamePlaceholder')" />
     </NFormItem>

--- a/src/views/_builtin/login/modules/register.vue
+++ b/src/views/_builtin/login/modules/register.vue
@@ -46,7 +46,7 @@ async function handleSubmit() {
 </script>
 
 <template>
-  <NForm ref="formRef" :model="model" :rules="rules" size="large" :show-label="false" @keyup.enter="handleSubmit">
+  <NForm ref="formRef" :model="model" :rules="rules" size="large" :show-label="false">
     <NFormItem path="phone">
       <NInput v-model:value="model.phone" :placeholder="$t('page.login.common.phonePlaceholder')" />
     </NFormItem>

--- a/src/views/_builtin/login/modules/reset-pwd.vue
+++ b/src/views/_builtin/login/modules/reset-pwd.vue
@@ -45,7 +45,7 @@ async function handleSubmit() {
 </script>
 
 <template>
-  <NForm ref="formRef" :model="model" :rules="rules" size="large" :show-label="false" @keyup.enter="handleSubmit">
+  <NForm ref="formRef" :model="model" :rules="rules" size="large" :show-label="false">
     <NFormItem path="phone">
       <NInput v-model:value="model.phone" :placeholder="$t('page.login.common.phonePlaceholder')" />
     </NFormItem>

--- a/src/views/manage/menu/index.vue
+++ b/src/views/manage/menu/index.vue
@@ -3,7 +3,7 @@ import { ref } from 'vue';
 import type { Ref } from 'vue';
 import { NButton, NPopconfirm, NTag } from 'naive-ui';
 import { useBoolean } from '@sa/hooks';
-import { fetchGetAllPages, fetchGetMenuList } from '@/service/api';
+import { fetchGetMenuList } from '@/service/api';
 import { useAppStore } from '@/store/modules/app';
 import { useTable, useTableOperate } from '@/hooks/common/table';
 import { $t } from '@/locales';
@@ -18,7 +18,7 @@ const { bool: visible, setTrue: openModal } = useBoolean();
 
 const wrapperRef = ref<HTMLElement | null>(null);
 
-const { columns, columnChecks, data, loading, pagination, getData, getDataByPage } = useTable({
+const { columns, columnChecks, data, loading, pagination, refresh, reload, getDataByPage } = useTable({
   apiFn: fetchGetMenuList,
   columns: () => [
     {
@@ -170,7 +170,7 @@ const { columns, columnChecks, data, loading, pagination, getData, getDataByPage
   ]
 });
 
-const { checkedRowKeys, onBatchDeleted, onDeleted } = useTableOperate(data, getData);
+const { checkedRowKeys, onBatchDeleted, onDeleted } = useTableOperate(data, reload);
 
 const operateType = ref<OperateType>('add');
 
@@ -210,20 +210,6 @@ function handleAddChildMenu(item: Api.SystemManage.Menu) {
 
   openModal();
 }
-
-const allPages = ref<string[]>([]);
-
-async function getAllPages() {
-  const { data: pages } = await fetchGetAllPages();
-  allPages.value = pages || [];
-}
-
-function init() {
-  getAllPages();
-}
-
-// init
-init();
 </script>
 
 <template>
@@ -236,7 +222,7 @@ init();
           :loading="loading"
           @add="handleAdd"
           @delete="handleBatchDelete"
-          @refresh="getData"
+          @refresh="refresh"
         />
       </template>
       <NDataTable
@@ -256,7 +242,6 @@ init();
         v-model:visible="visible"
         :operate-type="operateType"
         :row-data="editingData"
-        :all-pages="allPages"
         @submitted="getDataByPage"
       />
     </NCard>

--- a/src/views/manage/role/index.vue
+++ b/src/views/manage/role/index.vue
@@ -15,7 +15,8 @@ const {
   columnChecks,
   data,
   loading,
-  getData,
+  reload,
+  refresh,
   getDataByPage,
   mobilePagination,
   searchParams,
@@ -116,7 +117,7 @@ const {
   onBatchDeleted,
   onDeleted
   // closeDrawer
-} = useTableOperate(data, getData);
+} = useTableOperate(data, reload);
 
 async function handleBatchDelete() {
   // request
@@ -148,7 +149,7 @@ function edit(id: number) {
           :loading="loading"
           @add="handleAdd"
           @delete="handleBatchDelete"
-          @refresh="getData"
+          @refresh="refresh"
         />
       </template>
       <NDataTable

--- a/src/views/manage/user/index.vue
+++ b/src/views/manage/user/index.vue
@@ -10,132 +10,121 @@ import UserSearch from './modules/user-search.vue';
 
 const appStore = useAppStore();
 
-const {
-  columns,
-  columnChecks,
-  data,
-  getData,
-  getDataByPage,
-  loading,
-  mobilePagination,
-  searchParams,
-  resetSearchParams
-} = useTable({
-  apiFn: fetchGetUserList,
-  showTotal: true,
-  apiParams: {
-    current: 1,
-    size: 10,
-    // if you want to use the searchParams in Form, you need to define the following properties, and the value is null
-    // the value can not be undefined, otherwise the property in Form will not be reactive
-    status: null,
-    userName: null,
-    userGender: null,
-    nickName: null,
-    userPhone: null,
-    userEmail: null
-  },
-  columns: () => [
-    {
-      type: 'selection',
-      align: 'center',
-      width: 48
+const { columns, columnChecks, data, refresh, reload, loading, mobilePagination, searchParams, resetSearchParams } =
+  useTable({
+    apiFn: fetchGetUserList,
+    showTotal: true,
+    apiParams: {
+      // if you want to use the searchParams in Form, you need to define the following properties, and the value is null
+      // the value can not be undefined, otherwise the property in Form will not be reactive
+      status: null,
+      userName: null,
+      userGender: null,
+      nickName: null,
+      userPhone: null,
+      userEmail: null
     },
-    {
-      key: 'index',
-      title: $t('common.index'),
-      align: 'center',
-      width: 64
-    },
-    {
-      key: 'userName',
-      title: $t('page.manage.user.userName'),
-      align: 'center',
-      minWidth: 100
-    },
-    {
-      key: 'userGender',
-      title: $t('page.manage.user.userGender'),
-      align: 'center',
-      width: 100,
-      render: row => {
-        if (row.userGender === null) {
-          return null;
+    columns: () => [
+      {
+        type: 'selection',
+        align: 'center',
+        width: 48
+      },
+      {
+        key: 'index',
+        title: $t('common.index'),
+        align: 'center',
+        width: 64
+      },
+      {
+        key: 'userName',
+        title: $t('page.manage.user.userName'),
+        align: 'center',
+        minWidth: 100
+      },
+      {
+        key: 'userGender',
+        title: $t('page.manage.user.userGender'),
+        align: 'center',
+        width: 100,
+        render: row => {
+          if (row.userGender === null) {
+            return null;
+          }
+
+          const tagMap: Record<Api.SystemManage.UserGender, NaiveUI.ThemeColor> = {
+            1: 'primary',
+            2: 'error'
+          };
+
+          const label = $t(userGenderRecord[row.userGender]);
+
+          return <NTag type={tagMap[row.userGender]}>{label}</NTag>;
         }
+      },
+      {
+        key: 'nickName',
+        title: $t('page.manage.user.nickName'),
+        align: 'center',
+        minWidth: 100
+      },
+      {
+        key: 'userPhone',
+        title: $t('page.manage.user.userPhone'),
+        align: 'center',
+        width: 120
+      },
+      {
+        key: 'userEmail',
+        title: $t('page.manage.user.userEmail'),
+        align: 'center',
+        minWidth: 200
+      },
+      {
+        key: 'status',
+        title: $t('page.manage.user.userStatus'),
+        align: 'center',
+        width: 100,
+        render: row => {
+          if (row.status === null) {
+            return null;
+          }
 
-        const tagMap: Record<Api.SystemManage.UserGender, NaiveUI.ThemeColor> = {
-          1: 'primary',
-          2: 'error'
-        };
+          const tagMap: Record<Api.Common.EnableStatus, NaiveUI.ThemeColor> = {
+            1: 'success',
+            2: 'warning'
+          };
 
-        const label = $t(userGenderRecord[row.userGender]);
+          const label = $t(enableStatusRecord[row.status]);
 
-        return <NTag type={tagMap[row.userGender]}>{label}</NTag>;
-      }
-    },
-    {
-      key: 'nickName',
-      title: $t('page.manage.user.nickName'),
-      align: 'center',
-      minWidth: 100
-    },
-    {
-      key: 'userPhone',
-      title: $t('page.manage.user.userPhone'),
-      align: 'center',
-      width: 120
-    },
-    {
-      key: 'userEmail',
-      title: $t('page.manage.user.userEmail'),
-      align: 'center',
-      minWidth: 200
-    },
-    {
-      key: 'status',
-      title: $t('page.manage.user.userStatus'),
-      align: 'center',
-      width: 100,
-      render: row => {
-        if (row.status === null) {
-          return null;
+          return <NTag type={tagMap[row.status]}>{label}</NTag>;
         }
-
-        const tagMap: Record<Api.Common.EnableStatus, NaiveUI.ThemeColor> = {
-          1: 'success',
-          2: 'warning'
-        };
-
-        const label = $t(enableStatusRecord[row.status]);
-
-        return <NTag type={tagMap[row.status]}>{label}</NTag>;
+      },
+      {
+        key: 'operate',
+        title: $t('common.operate'),
+        align: 'center',
+        width: 130,
+        render: row => (
+          <div class="flex-center gap-8px">
+            <NButton type="primary" ghost size="small" onClick={() => edit(row.id)}>
+              {$t('common.edit')}
+            </NButton>
+            <NPopconfirm onPositiveClick={() => handleDelete(row.id)}>
+              {{
+                default: () => $t('common.confirmDelete'),
+                trigger: () => (
+                  <NButton type="error" ghost size="small">
+                    {$t('common.delete')}
+                  </NButton>
+                )
+              }}
+            </NPopconfirm>
+          </div>
+        )
       }
-    },
-    {
-      key: 'operate',
-      title: $t('common.operate'),
-      align: 'center',
-      width: 130,
-      render: row => (
-        <div class="flex-center gap-8px">
-          <NButton type="primary" ghost size="small" onClick={() => edit(row.id)}>
-            {$t('common.edit')}
-          </NButton>
-          <NPopconfirm onPositiveClick={() => handleDelete(row.id)}>
-            {{
-              default: () => $t('common.confirmDelete'),
-              trigger: () => (
-                <NButton type="error" ghost size="small">
-                  {$t('common.delete')}
-                </NButton>
-              )
-            }}
-          </NPopconfirm>
-        </div>
-      )
-    }
-  ]
-});
+    ]
+  });
 
 const {
   drawerVisible,
@@ -147,7 +136,7 @@ const {
   onBatchDeleted,
   onDeleted
   // closeDrawer
-} = useTableOperate(data, getData);
+} = useTableOperate(data, reload);
 
 async function handleBatchDelete() {
   // request
@@ -170,7 +159,7 @@ function edit(id: number) {
 
 <template>
   <div class="min-h-500px flex-col-stretch gap-16px overflow-hidden lt-sm:overflow-auto">
-    <UserSearch v-model:model="searchParams" @reset="resetSearchParams" @search="getDataByPage" />
+    <UserSearch v-model:model="searchParams" @reset="resetSearchParams" @search="reload" />
     <NCard :title="$t('page.manage.user.title')" :bordered="false" size="small" class="sm:flex-1-hidden card-wrapper">
       <template #header-extra>
         <TableHeaderOperation
@@ -179,7 +168,7 @@ function edit(id: number) {
           :loading="loading"
           @add="handleAdd"
           @delete="handleBatchDelete"
-          @refresh="getData"
+          @refresh="refresh"
         />
       </template>
       <NDataTable
@@ -199,7 +188,7 @@ function edit(id: number) {
         v-model:visible="drawerVisible"
         :operate-type="operateType"
         :row-data="editingData"
-        @submitted="getDataByPage"
+        @submitted="reload"
       />
     </NCard>
   </div>


### PR DESCRIPTION
此pr包含以下修改，保持了与`@sa/axios`相同的效果：

## 添加`@sa/alova`子包

通过77行代码实现了比`@sa/axios`更丰富的特性，具体如下：

1. 尽量与`@sa/axios`的封装设计保持了一致
2. 自带了token无感刷新特性，不再需要自行实现，并且在刷新token期间发送的请求将会挂起等待，刷新完成自动重新请求
3. 因不再需要自行实现token刷新，去除了`onBackendFail`钩子
4. 可自定义请求适配器，默认使用fetch适配器

## 使用`@sa/alova`重构views

1. `src/service/api`下改用`@sa/alova`
2. 使用alova的`usePagination`重构了`packages/hooks/src/use-table.ts`和`src/hooks/common/table.ts`，删除了大量与`usePagination`重复的代码，既兼容了之前的用法，也保留了`usePagination`的所有特性，例如对列表下一页数据做预加载。并对用户列表、角色列表和菜单列表做了小调整。
3. 对以下组件中的权限列表、页面列表等的获取，使用`useWatcher`进行重构：
  - 用户操作抽屉`src\views\manage\user\modules\user-operate-drawer.vue`
  - 菜单权限弹框`src\views\manage\role\modules\menu-auth-modal.vue`
  - 菜单操作弹框`src\views\manage\menu\modules\menu-operate-modal.vue`
4. 由于表单提交未找到可用的api，暂无法使用`useForm`重构。

## 部分优化

1. 对以上弹框和抽屉内的数据获取添加了`loading`效果
2. 发现菜单列表`src\views\manage\menu\index.vue`中的`allPages`数据只在菜单操作弹框`src\views\manage\menu\modules\menu-operate-modal.vue`内使用，因此将`allPages`的数据获取移动到了菜单操作弹框中，实现弹框显示再加载的效果
