### PR TITLE
Update src\router\guard\route.ts  handleRouteSwitch 取消跳转

### DIFF
--- a/src/router/guard/route.ts
+++ b/src/router/guard/route.ts
@@ -189,7 +189,7 @@ function handleRouteSwitch(to: RouteLocationNormalized, from: RouteLocationNorma
   if (to.meta.href) {
     window.open(to.meta.href, '_blank');
 
-    next({ path: from.fullPath, replace: true, query: from.query, hash: to.hash });
+    next(false);
 
     return;
   }


### PR DESCRIPTION
如果 `next({ path: from.fullPath, replace: true, query: from.query, hash: to.hash });` 的意图是取消跳转的话

使用 next(false) 更准确。 

而使用replace ，也许会和用户代码 一起产生 非预期的可能