### PR TITLE
fix(setupAppVersionNotification): 修复当处于处于二级目录时，请求地址错误的bug

### DIFF
--- a/src/plugins/app.ts
+++ b/src/plugins/app.ts
@@ -64,7 +64,8 @@ export function setupAppVersionNotification() {
 }
 
 async function getHtmlBuildTime() {
-  const res = await fetch(`/index.html?time=${Date.now()}`);
+  const baseUrl = import.meta.env.VITE_BASE_URL === '/' ? '' : import.meta.env.VITE_BASE_URL
+  const res = await fetch(`${baseUrl}/index.html?time=${Date.now()}`);
 
   const html = await res.text();
 


### PR DESCRIPTION
修复当`VITE_BASE_URL=/anypath` 为任意二级目录时，请求地址不一致的bug