### PR TITLE
build(deps): Restrict the minimum Node.js version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "UnoCSS"
   ],
   "engines": {
-    "node": ">=18.12.0",
+    "node": ">=18.20.0",
     "pnpm": ">=8.7.0"
   },
   "scripts": {


### PR DESCRIPTION
Node 18.20.0以下的版本,执行`pnpm lint` 会报错，`@soybeanjs/eslint-config` 中的依赖 `eslint-plugin-unicorn` 使用了
```js
// /node_modules/eslint-plugin-unicorn/index.js  第4行

import packageJson from  './package.json' with {type: 'json'};
```