### PR TITLE
fix(tab): fix active tab switch issue after removal

### DIFF
--- a/packages/materials/src/libs/page-tab/index.vue
+++ b/packages/materials/src/libs/page-tab/index.vue
@@ -63,7 +63,7 @@ function handleClose() {
     <slot></slot>
     <template #suffix>
       <slot name="suffix">
-        <SvgClose v-if="closable" :class="[style['svg-close']]" @click.stop="handleClose" />
+        <SvgClose v-if="closable" :class="[style['svg-close']]" @pointerdown.stop="handleClose" />
       </slot>
     </template>
   </component>

--- a/src/store/modules/tab/index.ts
+++ b/src/store/modules/tab/index.ts
@@ -10,7 +10,6 @@ import { SetupStoreId } from '@/enum';
 import { useThemeStore } from '../theme';
 import {
   extractTabsByAllRoutes,
-  filterTabsById,
   filterTabsByIds,
   findTabByRouteName,
   getAllTabs,
@@ -96,24 +95,14 @@ export const useTabStore = defineStore(SetupStoreId.Tab, () => {
    * @param tabId Tab id
    */
   async function removeTab(tabId: string) {
+    const removeTabIndex = tabs.value.findIndex(tab => tab.id === tabId);
+    if (removeTabIndex === -1) return;
+
     const isRemoveActiveTab = activeTabId.value === tabId;
-    const updatedTabs = filterTabsById(tabId, tabs.value);
+    const nextTab = tabs.value[removeTabIndex + 1] || homeTab.value;
 
-    function update() {
-      tabs.value = updatedTabs;
-    }
-
-    if (!isRemoveActiveTab) {
-      update();
-      return;
-    }
-
-    const activeTab = updatedTabs.at(-1) || homeTab.value;
-
-    if (activeTab) {
-      await switchRouteByTab(activeTab);
-      update();
-    }
+    tabs.value.splice(removeTabIndex, 1);
+    if (isRemoveActiveTab && nextTab) await switchRouteByTab(nextTab);
   }
 
   /** remove active tab */


### PR DESCRIPTION
## 1. Use the same event to prevent event bubbling
- In Vue 3, @click.stop can only prevent click events from bubbling, not pointer down events, because pointer down occurs before click and is a lower-level event.

## 2. Modify the removeTab function. When I used it, I found a bug in the closing function.

- When closing the ‘about’ tab, it should jump to the next tab instead of jumping to the last tab in the tab array.
![soybeanjs cn_manage_menu (1)](https://github.com/user-attachments/assets/361daabe-01e3-4da1-aefb-c77ab5258a57)
when close 'abot' happened:
![soybeanjs cn_manage_menu](https://github.com/user-attachments/assets/8e7b795e-6f9a-4a86-8ade-f3160d12f6e1)
should be like:
![localhost_9527_home](https://github.com/user-attachments/assets/bb2c9a93-8e3a-43c4-8956-320103c350f8)

- When closing a tab that is not the current one, it should not jump, instead of jumping to the last tab in the tab array.
![soybeanjs cn_manage_menu (2)](https://github.com/user-attachments/assets/18747e9b-4cb4-42d4-b7a8-5f4c929fa168)
when close '500' happened:
![soybeanjs cn_manage_menu (4)](https://github.com/user-attachments/assets/87cce58b-b9ab-4988-8184-116ba0ca53c6)
should be like:
![localhost_9527_home (1)](https://github.com/user-attachments/assets/23c2dc25-9caa-44e7-96de-6542017d2231)


- Optimized `removeTab` to use index-based removal for better efficiency.
- Ensured the next tab was selected correctly when removing the active tab.
- Prevented unnecessary state updates.