### PR TITLE
feat(projects): support vite devtools specify the editor by launchEdi…

### DIFF
--- a/.env
+++ b/.env
@@ -54,3 +54,7 @@ VITE_AUTOMATICALLY_DETECT_UPDATE=Y
 
 # show proxy url log in terminal
 VITE_PROXY_LOG=Y
+
+# used to control whether to launch editor
+# by the way, this plugin is only available in dev mode, not in build mode
+VITE_DEVTOOLS_LAUNCH_EDITOR=code

--- a/build/plugins/devtools.ts
+++ b/build/plugins/devtools.ts
@@ -1,0 +1,9 @@
+import VueDevtools from 'vite-plugin-vue-devtools';
+
+export function setupDevtoolsPlugin(viteEnv: Env.ImportMeta) {
+  const { VITE_DEVTOOLS_LAUNCH_EDITOR } = viteEnv;
+
+  return VueDevtools({
+    launchEditor: VITE_DEVTOOLS_LAUNCH_EDITOR
+  });
+}

--- a/build/plugins/index.ts
+++ b/build/plugins/index.ts
@@ -1,18 +1,18 @@
 import type { PluginOption } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import vueJsx from '@vitejs/plugin-vue-jsx';
-import VueDevtools from 'vite-plugin-vue-devtools';
 import progress from 'vite-plugin-progress';
 import { setupElegantRouter } from './router';
 import { setupUnocss } from './unocss';
 import { setupUnplugin } from './unplugin';
 import { setupHtmlPlugin } from './html';
+import { setupDevtoolsPlugin } from './devtools';
 
 export function setupVitePlugins(viteEnv: Env.ImportMeta, buildTime: string) {
   const plugins: PluginOption = [
     vue(),
     vueJsx(),
-    VueDevtools(),
+    setupDevtoolsPlugin(viteEnv),
     setupElegantRouter(),
     setupUnocss(viteEnv),
     ...setupUnplugin(viteEnv),

--- a/src/typings/vite-env.d.ts
+++ b/src/typings/vite-env.d.ts
@@ -108,6 +108,8 @@ declare namespace Env {
     readonly VITE_AUTOMATICALLY_DETECT_UPDATE?: CommonType.YesOrNo;
     /** show proxy url log in terminal */
     readonly VITE_PROXY_LOG?: CommonType.YesOrNo;
+    /** The launch editor */
+    readonly VITE_DEVTOOLS_LAUNCH_EDITOR?: import('vite-plugin-vue-devtools').VitePluginVueDevToolsOptions['launchEditor'];
   }
 }
 


### PR DESCRIPTION
…tor option.

支持通过配置的方式指定devtools打开的编辑器，默认为code（vscode or cursor都可用这个打开）
单独建一个文件主要是考虑到后续可能有新版的路由插件或者是其他的开发时工具使用，并且这样的话在index里可以继续保持干净