### PR TITLE
fix(hooks): fixed the issue where loading was not properly closed in some cases.

### DIFF
--- a/src/hooks/common/echarts.ts
+++ b/src/hooks/common/echarts.ts
@@ -210,6 +210,10 @@ export function useEcharts<T extends ECOption>(optionsFactory: () => T, hooks: C
 
     // render chart
     await render();
+
+    if (chart) {
+      await onUpdated?.(chart);
+    }
   }
 
   scope.run(() => {


### PR DESCRIPTION
部分情况下，图表触发renderChartBySize后，loading不会关闭，例如放在v-if、v-show中的chart，NTab中切换的chart，keepAlive之后的页面的chart。

复现路径：
1. 为home路由添加keepAlive
2. 切换到其他页面，再切回来，会发现loading效果仍然存在

造成这个bug的原因是：
使用这类的方式切换显示之后，useElementSize会侦测到他们的宽高变成0，进而触发针对width与height的watch，导致执行了renderChartBySize，切换回来后页面没有根据这个状态主动再次调用updateOptions（这个情况不应由页面去侦听调用），所以就导致图表数据正常，显示正常，但是loading会一直存在