### PR TITLE
feat(projects): add configurable user name watermark option

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,6 +4,7 @@ import { NConfigProvider, darkTheme } from 'naive-ui';
 import type { WatermarkProps } from 'naive-ui';
 import { useAppStore } from './store/modules/app';
 import { useThemeStore } from './store/modules/theme';
+import { useAuthStore } from './store/modules/auth';
 import { naiveDateLocales, naiveLocales } from './locales/naive';
 
 defineOptions({
@@ -12,6 +13,7 @@ defineOptions({
 
 const appStore = useAppStore();
 const themeStore = useThemeStore();
+const authStore = useAuthStore();
 
 const naiveDarkTheme = computed(() => (themeStore.darkMode ? darkTheme : undefined));
 
@@ -24,8 +26,13 @@ const naiveDateLocale = computed(() => {
 });
 
 const watermarkProps = computed<WatermarkProps>(() => {
+  const content =
+    themeStore.watermark.enableUserName && authStore.userInfo.userName
+      ? authStore.userInfo.userName
+      : themeStore.watermark.text;
+
   return {
-    content: themeStore.watermark.text,
+    content,
     cross: true,
     fullscreen: true,
     fontSize: 16,

--- a/src/layouts/modules/theme-drawer/modules/page-fun.vue
+++ b/src/layouts/modules/theme-drawer/modules/page-fun.vue
@@ -117,7 +117,10 @@ const isWrapperScrollMode = computed(() => themeStore.layout.scrollMode === 'wra
     <SettingItem key="8" :label="$t('theme.watermark.visible')">
       <NSwitch v-model:value="themeStore.watermark.visible" />
     </SettingItem>
-    <SettingItem v-if="themeStore.watermark.visible" key="8-1" :label="$t('theme.watermark.text')">
+    <SettingItem v-if="themeStore.watermark.visible" key="8-1" :label="$t('theme.watermark.enableUserName')">
+      <NSwitch v-model:value="themeStore.watermark.enableUserName" />
+    </SettingItem>
+    <SettingItem v-if="themeStore.watermark.visible" key="8-2" :label="$t('theme.watermark.text')">
       <NInput
         v-model:value="themeStore.watermark.text"
         autosize

--- a/src/locales/langs/en-us.ts
+++ b/src/locales/langs/en-us.ts
@@ -143,7 +143,8 @@ const local: App.I18n.Schema = {
     },
     watermark: {
       visible: 'Watermark Full Screen Visible',
-      text: 'Watermark Text'
+      text: 'Watermark Text',
+      enableUserName: 'Enable User Name Watermark'
     },
     themeDrawerTitle: 'Theme Configuration',
     pageFunTitle: 'Page Function',

--- a/src/locales/langs/zh-cn.ts
+++ b/src/locales/langs/zh-cn.ts
@@ -143,7 +143,8 @@ const local: App.I18n.Schema = {
     },
     watermark: {
       visible: '显示全屏水印',
-      text: '水印文本'
+      text: '水印文本',
+      enableUserName: '启用用户名水印'
     },
     themeDrawerTitle: '主题配置',
     pageFunTitle: '页面功能',

--- a/src/theme/settings.ts
+++ b/src/theme/settings.ts
@@ -58,7 +58,8 @@ export const themeSettings: App.Theme.ThemeSetting = {
   },
   watermark: {
     visible: false,
-    text: 'SoybeanAdmin'
+    text: 'SoybeanAdmin',
+    enableUserName: false
   },
   tokens: {
     light: {

--- a/src/typings/app.d.ts
+++ b/src/typings/app.d.ts
@@ -112,6 +112,8 @@ declare namespace App {
         visible: boolean;
         /** Watermark text */
         text: string;
+        /** Whether to use user name as watermark text */
+        enableUserName: boolean;
       };
       /** define some theme settings tokens, will transform to css variables */
       tokens: {
@@ -408,6 +410,7 @@ declare namespace App {
         watermark: {
           visible: string;
           text: string;
+          enableUserName: string;
         };
         themeDrawerTitle: string;
         pageFunTitle: string;


### PR DESCRIPTION
This PR adds a new configuration option that allows users to set username as the watermark content.

- Added `enableUserName: boolean` to watermark settings
- Default value set to `false` for backward compatibility
- When enabled and user is logged in, displays username as watermark