### PR TITLE
fix(projects): ensure proper text color when themes are inverted

### DIFF
--- a/src/styles/css/global.css
+++ b/src/styles/css/global.css
@@ -10,4 +10,5 @@ body,
 
 html {
   overflow-x: hidden;
+  color: rgb(var(--base-text-color));
 }


### PR DESCRIPTION
fix #764 