### PR TITLE
fix(other): 修复当设置moduleResolution为bundler时,i18n-ally不工作问题

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,9 @@
   "i18n-ally.editor.preferEditor": true,
   "i18n-ally.keystyle": "nested",
   "i18n-ally.localesPaths": ["src/locales/langs"],
+  "i18n-ally.parsers.typescript.compilerOptions": {
+    "moduleResolution": "node"
+  },
   "prettier.enable": false,
   "typescript.tsdk": "node_modules/typescript/lib",
   "unocss.root": ["./"],


### PR DESCRIPTION
通过单独设置i18n-ally插件的**moduleResolution**配置解决 #780