### PR TITLE
feat(styles): tabs can be scrolled with a wheel.

### DIFF
--- a/src/layouts/modules/global-tab/index.vue
+++ b/src/layouts/modules/global-tab/index.vue
@@ -164,7 +164,7 @@ init();
 
 <template>
   <DarkModeContainer class="size-full flex-y-center px-16px shadow-tab">
-    <div ref="bsWrapper" class="h-full flex-1-hidden">
+    <div ref="bsWrapper" class="h-full flex-1 overflow-x-auto overflow-y-hidden scrollbar-none">
       <BetterScroll ref="bsScroll" :options="{ scrollX: true, scrollY: false, click: !isPCFlag }" @click="removeFocus">
         <div
           ref="tabRef"

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -25,6 +25,7 @@ export default defineConfig<Theme>({
   shortcuts: {
     'card-wrapper': 'rd-8px shadow-sm'
   },
+  rules: [['scrollbar-none', { 'scrollbar-width': 'none' }]],
   transformers: [transformerDirectives(), transformerVariantGroup()],
   presets: [presetWind3({ dark: 'class' }), presetSoybeanAdmin()]
 });


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c8b3e734-9a67-4a93-8e11-3a679177702c)
当多个标签的长度超出容器后，无法通过Shift + 滚轮的形式去移动滚动条，一般网站或应用都是可以这样操作的，所以修改了部分样式，支持这个操作。
