### PR TITLE
fix(packages): fix the parsing logic for stored data to ensure correct return of boolean values

### DIFF
--- a/packages/utils/src/storage.ts
+++ b/packages/utils/src/storage.ts
@@ -32,7 +32,8 @@ export function createStorage<T extends object>(type: StorageType, storagePrefix
           storageData = JSON.parse(json);
         } catch {}
 
-        if (storageData) {
+        // storageData may be `false` if it is boolean type
+        if (storageData !== null) {
           return storageData as T[K];
         }
       }


### PR DESCRIPTION
Fix the parsing logic of stored data to ensure the correct return of the boolean value `false`.

**Before:**

When an item with a value of `false` is retrieved from localstorage, it will be immediately deleted, resulting in the retrieval always being `null`

**Now:**

When retrieving an item with a value of `false` from localstorage, the `false` value is correctly retrieved.