### PR TITLE
支持通过路由 meta.isDev 实现仅开发环境加载的路由

### DIFF
--- a/src/constants/env.ts
+++ b/src/constants/env.ts
@@ -1,0 +1,2 @@
+// Whether the app is running in the development environment
+export const isDev = import.meta.env.DEV;

--- a/src/store/modules/route/index.ts
+++ b/src/store/modules/route/index.ts
@@ -13,6 +13,7 @@ import { useAuthStore } from '../auth';
 import { useTabStore } from '../tab';
 import {
   filterAuthRoutesByRoles,
+  filterRoutesByDev,
   getBreadcrumbsByRoute,
   getCacheRouteNames,
   getGlobalMenusByAuthRoutes,
@@ -231,7 +232,7 @@ export const useRouteStore = defineStore(SetupStoreId.Route, () => {
 
   /** handle constant and auth routes */
   function handleConstantAndAuthRoutes() {
-    const allRoutes = [...constantRoutes.value, ...authRoutes.value];
+    const allRoutes = filterRoutesByDev([...constantRoutes.value, ...authRoutes.value]);
 
     const sortRoutes = sortRoutesByOrder(allRoutes);
 

--- a/src/store/modules/route/shared.ts
+++ b/src/store/modules/route/shared.ts
@@ -1,5 +1,6 @@
 import type { RouteLocationNormalizedLoaded, RouteRecordRaw, _RouteRecordBase } from 'vue-router';
 import type { ElegantConstRoute, LastLevelRouteKey, RouteKey, RouteMap } from '@elegant-router/types';
+import { isDev } from '@/constants/env';
 import { useSvgIcon } from '@/hooks/common/icon';
 import { $t } from '@/locales';
 
@@ -40,6 +41,47 @@ function filterAuthRouteByRoles(route: ElegantConstRoute, roles: string[]): Eleg
   }
 
   return hasPermission || isEmptyRoles ? [filterRoute] : [];
+}
+
+/**
+ * Filter routes by `isDev` of meta
+ *
+ * The route with `meta.isDev` set to true is only loaded in the development environment
+ *
+ * @param routes Auth routes
+ */
+export function filterRoutesByDev(routes: ElegantConstRoute[]) {
+  // in the development environment, all routes are loaded
+  if (isDev) {
+    return routes;
+  }
+
+  return routes.flatMap(route => filterRouteByDev(route));
+}
+
+/**
+ * Filter route by `isDev` of meta
+ *
+ * @param route Auth route
+ */
+function filterRouteByDev(route: ElegantConstRoute): ElegantConstRoute[] {
+  // exclude the route configured with `meta.isDev` outside the development environment
+  if (route.meta?.isDev) {
+    return [];
+  }
+
+  const filterRoute = { ...route };
+
+  if (filterRoute.children?.length) {
+    filterRoute.children = filterRoute.children.flatMap(item => filterRouteByDev(item));
+  }
+
+  // Exclude the route if it has no children after filtering
+  if (filterRoute.children?.length === 0) {
+    return [];
+  }
+
+  return [filterRoute];
 }
 
 /**

--- a/src/typings/router.d.ts
+++ b/src/typings/router.d.ts
@@ -68,5 +68,12 @@ declare module 'vue-router' {
     fixedIndexInTab?: number | null;
     /** if set query parameters, it will be automatically carried when entering the route */
     query?: { key: string; value: string }[] | null;
+    /**
+     * Whether the route is only available in the development environment
+     *
+     * When set to true, the route will only be loaded if `import.meta.env.DEV` is true, even if the route mode is
+     * "dynamic"
+     */
+    isDev?: boolean;
   }
 }


### PR DESCRIPTION
## 背景

部分菜单/路由（如调试页、内部工具、组件示例等）只希望在开发环境出现，在生产环境中应当被完全隐藏——既不注册到 vue-router，也不出现在菜单中。本 PR 为路由 `meta` 新增 `isDev` 配置项来支持这一能力，并顺带沉淀一个可复用的 `isDev` 环境常量。

## 变更内容

本 PR 包含两个提交：

### 1. `feat(constants)`：导出 `isDev` 环境常量

新增 `src/constants/env.ts`，导出一个语义化的环境标识，作为开发环境判断的唯一来源，避免在业务代码里散落 `import.meta.env.DEV`：

```ts
// Whether the app is running in the development environment
export const isDev = import.meta.env.DEV;
```

### 2. `feat(router)`：支持 `meta.isDev` 仅开发环境加载路由

- **类型定义** `src/typings/router.d.ts`：为 `RouteMeta` 新增可选项 `isDev?: boolean`。
- **过滤逻辑** `src/store/modules/route/shared.ts`：新增 `filterRoutesByDev`，复用 `filterAuthRoutesByRoles` 既有的递归裁剪范式——开发环境下原样返回，非开发环境下递归剔除 `meta.isDev` 的路由，并自动清理因子路由被全部剔除而变空的父级路由。判断条件统一引用第一个提交导出的 `isDev` 常量。
- **接入位置** `src/store/modules/route/index.ts`：在 `handleConstantAndAuthRoutes` 这一**唯一汇聚点**应用过滤。该函数被 `initConstantRoute`、`initStaticAuthRoute`、`initDynamicAuthRoute` 三条初始化链路共同调用，因此一处过滤即可同时作用于：注册到 vue-router 的路由、生成的菜单、以及 keep-alive 缓存列表。

## 使用方式

在任意路由的 `meta` 中配置 `isDev: true` 即可：

```ts
{
  name: 'demo_dev-only',
  path: '/demo/dev-only',
  meta: {
    title: 'dev-only',
    isDev: true // 仅当 import.meta.env.DEV 为 true 时加载
  }
}
```

## 行为说明

| 场景 | `import.meta.env.DEV` | 是否加载 |
| --- | --- | --- |
| 配置了 `meta.isDev: true` | `true`（开发） | ✅ 加载 |
| 配置了 `meta.isDev: true` | `false`（生产/测试） | ❌ 不加载（路由 + 菜单均隐藏） |
| 未配置 / `meta.isDev: false` | 任意 | ✅ 正常加载 |

- **静态路由与动态路由（后端下发）均生效**：由于过滤发生在所有模式共用的汇聚点，动态路由同样遵从该规则。
- **不影响现有路由**：未配置 `isDev` 的路由行为完全不变。

## 自测

- [x] `pnpm typecheck` 通过
- [x] `pnpm lint` / `pnpm fmt` 通过（pre-commit 钩子已校验）
- [x] 开发环境下 `meta.isDev` 路由与菜单正常显示
- [x] 生产构建（`pnpm build`）下 `meta.isDev` 路由不注册、菜单不显示
