### PR TITLE
feat(layout): support mouse wheel horizontal scroll on global tab

### DIFF
--- a/src/constants/app.ts
+++ b/src/constants/app.ts
@@ -4,6 +4,9 @@ export const GLOBAL_HEADER_MENU_ID = '__GLOBAL_HEADER_MENU__';
 
 export const GLOBAL_SIDER_MENU_ID = '__GLOBAL_SIDER_MENU__';
 
+/** Wheel speed ratio for horizontal scrolling on the global tab bar. <1 slower, >1 faster */
+export const GLOBAL_TAB_WHEEL_SPEED_RATIO = 0.3;
+
 export const themeSchemaRecord: Record<UnionKey.ThemeScheme, App.I18n.I18nKey> = {
   light: 'theme.appearance.themeSchema.light',
   dark: 'theme.appearance.themeSchema.dark',

--- a/src/layouts/modules/global-tab/index.vue
+++ b/src/layouts/modules/global-tab/index.vue
@@ -7,6 +7,7 @@ import { useAppStore } from '@/store/modules/app';
 import { useThemeStore } from '@/store/modules/theme';
 import { useTabStore } from '@/store/modules/tab';
 import { isPC } from '@/utils/agent';
+import { GLOBAL_TAB_WHEEL_SPEED_RATIO } from '@/constants/app';
 import BetterScroll from '@/components/custom/better-scroll.vue';
 import ContextMenu from './context-menu.vue';
 
@@ -69,6 +70,17 @@ function scrollByClientX(clientX: number) {
 
     scrollBy(update, 0, 300);
   }
+}
+
+// Convert vertical wheel delta into horizontal tab scroll
+function handleWheel(e: WheelEvent) {
+  const bs = bsScroll.value?.instance;
+  if (!bs) return;
+  // Do not intercept when there is no horizontal scroll space, keep native vertical scrolling
+  if (bs.maxScrollX === 0) return;
+  e.preventDefault();
+  // deltaY > 0 (scroll down) -> tabs slide left; deltaY < 0 (scroll up) -> tabs slide right
+  bs.scrollBy(-e.deltaY * GLOBAL_TAB_WHEEL_SPEED_RATIO, 0, 0);
 }
 
 function getContextMenuDisabledKeys(tabId: string) {
@@ -186,7 +198,7 @@ init();
 
 <template>
   <DarkModeContainer class="size-full flex-y-center px-16px shadow-tab">
-    <div ref="bsWrapper" class="h-full flex-1-hidden">
+    <div ref="bsWrapper" class="h-full flex-1-hidden" @wheel="handleWheel">
       <BetterScroll ref="bsScroll" :options="{ scrollX: true, scrollY: false, click: !isPCFlag }" @click="removeFocus">
         <div
           ref="tabRef"


### PR DESCRIPTION
## 背景

当标签页数量较多时，现有标签栏只能通过**点住某个标签后拖动**才能查看其他标签，操作不便。用户期望在鼠标进入标签栏区域时，可以直接用**鼠标滚轮**让标签左右滑动，同时保留现有所有功能（拖拽、中键关闭、右键菜单等）。

## 改动内容

在 `src/layouts/modules/global-tab/index.vue` 中新增滚轮横向滑动支持：

1. 新增 `handleWheel` 函数：监听 `wheel` 事件，将滚轮的纵向 `deltaY` 转换为 BetterScroll 实例的横向 `scrollBy` 偏移
   - 向下滚动 → 标签向左滑动（露出右侧标签）
   - 向上滚动 → 标签向右滑动（露出左侧标签）
2. 提取力度倍率常量 `WHEEL_SPEED_RATIO`，便于后续按手感调整（< 1 减慢，> 1 加快）
3. 在外层 `bsWrapper` 容器上绑定 `@wheel="handleWheel"`

## 兼容性保障

- 当标签未溢出（`bs.maxScrollX === 0`，横向无滚动空间）时**不拦截事件**，避免影响页面正常纵向滚动
- 不修改任何现有功能（拖拽、中键关闭、右键菜单、点击切换、激活标签自动滚动到可视区等全部保留）

## 验证

- `pnpm typecheck` 通过（0 error）
- `pnpm lint` 通过（0 warnings, 0 errors）
- 本地实测：鼠标进入标签栏滚轮可左右滑动，标签少时不拦截页面滚动

## 截图 / 录屏

<!-- 建议附上一个标签很多时的滚轮操作录屏 gif，维护者会更直观理解（可选）-->